### PR TITLE
Fix dismount causes segfault

### DIFF
--- a/assetsys.h
+++ b/assetsys.h
@@ -6068,7 +6068,7 @@ assetsys_error_t assetsys_dismount( assetsys_t* sys, char const* path, char cons
             ASSETSYS_FREE( sys->memctx, mount->files );
 
             int count = sys->mounts_count - i;
-            if( count > 0 ) memcpy( &sys->mounts[ i ], &sys->mounts[ i + 1 ], sizeof( *sys->mounts ) * count );
+            if( count > 0 ) memmove( &sys->mounts[ i ], &sys->mounts[ i + 1 ], sizeof( *sys->mounts ) * count );
             --sys->mounts_count;
 
             return !result ? ASSETSYS_ERROR_FAILED_TO_CLOSE_ZIP : ASSETSYS_SUCCESS;


### PR DESCRIPTION
On linux `dismounting` causes segfault in some cases. This happens due to the memory address overlapping takes place while using `memcpy` when `mounts` are being moved. Memcpy manual recommends not to use `memcpy` on overlapped memory portions, but use `memmove` instead. 
In my tests, since `count` is always miscalculated, i.e. being on 1 bigger than it should, this made `memcpy` to copy oob portions of memory along with with the valid one, but due to undefined behavior while moving overlapped memory areas, this caused the last `mount` item to be replaced with the oob portion that had some garbage in it, and upon freeing the last `mount`, segfault would occur. 
This doesn't happen on Windows though. Another solution i found is to reduce the count on one in its equation, but this still doesn't guarantee any consistency due to behavior specifics of `memcpy` on linux.