### PR TITLE
Add errno.h include

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -612,6 +612,7 @@ struct thread_queue_t
 #elif defined( __linux__ ) || defined( __APPLE__ ) || defined( __ANDROID__ )
 
     #include <pthread.h>
+    #include <errno.h>
     #include <sys/time.h>
 
 #else 


### PR DESCRIPTION
Avoid "error: use of undeclared identifier 'ETIMEDOUT'" on Mac OS X.

I had a compilation issue on Mac OS X 10.15.4
```
thread.h:1000:95: error: use of undeclared identifier 'ETIMEDOUT'
  ...&internal->condition, &internal->mutex, &ts ) == ETIMEDOUT )
```

I fixed it by adding `#include <errno.h>`