### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/app.h
+++ b/app.h
@@ -635,7 +635,7 @@ app_input
 
     app_input_t app_input( app_t* app )
 
-Returns a list of input events which occured since the last call to `app_input`. Each input event can be of one of a
+Returns a list of input events which occurred since the last call to `app_input`. Each input event can be of one of a
 list of types, and the `type` field of the `app_input_event_t` struct specifies which type the event is. The `data`
 struct is a union of fields, where only one of them is valid, depending on the value of `type`:
 * APP_INPUT_KEY_DOWN, APP_INPUT_KEY_UP, APP_INPUT_DOUBLE_CLICK - use the `key` field of the `data` union, which contains

--- a/assetsys.h
+++ b/assetsys.h
@@ -411,7 +411,7 @@ path. If the path is invalid or index is out of range, `assetsys_subdir_path` re
    * Change History
      10/13/13 v1.15 r4 - Interim bugfix release while I work on the next major release with Zip64 support (almost there!):
        - Critical fix for the MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY bug (thanks kahmyong.moon@hp.com) which could cause locate files to not find files. This bug
-        would only have occured in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
+        would only have occurred in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
         (which used this flag). If you can't switch to v1.15 but want to fix this bug, just remove the uses of this flag from both helper funcs (and of course don't use the flag).
        - Bugfix in mz_zip_reader_extract_to_mem_no_alloc() from kymoon when pUser_read_buf is not NULL and compressed size is > uncompressed size
        - Fixing mz_zip_reader_extract_*() funcs so they don't try to extract compressed data from directory entries, to account for weird zipfiles which contain zero-size compressed data on dir entries.

--- a/docs/app.md
+++ b/docs/app.md
@@ -492,7 +492,7 @@ app_input
 
 	app_input_t app_input( app_t* app )
 
-Returns a list of input events which occured since the last call to `app_input`. Each input event can be of one of a 
+Returns a list of input events which occurred since the last call to `app_input`. Each input event can be of one of a 
 list of types, and the `type` field of the `app_input_event_t` struct specifies which type the event is. The `data`
 struct is a union of fields, where only one of them is valid, depending on the value of `type`:
 * APP_INPUT_KEY_DOWN, APP_INPUT_KEY_UP, APP_INPUT_DOUBLE_CLICK - use the `key` field of the `data` union, which contains


### PR DESCRIPTION
There is a small typo in app.h, assetsys.h, docs/app.md.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md