### PR TITLE
http.h: Do not add port 80 to Host header

### DIFF
--- a/http.h
+++ b/http.h
@@ -420,7 +420,8 @@ http_t* http_get( char const* url, void* memctx )
         internal->request_header_large = (char*) HTTP_MALLOC( memctx, request_header_len + 1 );
         request_header = internal->request_header_large;
         }       
-    sprintf( request_header, "GET %s HTTP/1.0\r\nHost: %s:%s\r\n\r\n", resource, address, port );
+    int default_http_port = (strcmp(port, "80") == 0);
+    sprintf( request_header, "GET %s HTTP/1.0\r\nHost: %s%s%s\r\n\r\n", resource, address, default_http_port ? "" : ":", default_http_port ? "" : port );
     
     return &internal->http;
     }
@@ -458,7 +459,8 @@ http_t* http_post( char const* url, void const* data, size_t size, void* memctx 
         internal->request_header_large = (char*) HTTP_MALLOC( memctx, request_header_len + 1 );
         request_header = internal->request_header_large;
         }       
-    sprintf( request_header, "POST %s HTTP/1.0\r\nHost: %s:%s\r\nContent-Length: %d\r\n\r\n", resource, address, port, 
+    int default_http_port = (strcmp(port, "80") == 0);
+    sprintf( request_header, "POST %s HTTP/1.0\r\nHost: %s%s%s\r\nContent-Length: %d\r\n\r\n", resource, address, default_http_port ? "" : ":", default_http_port ? "" : port, 
         (int) size );
     
     internal->request_data_size = size;


### PR DESCRIPTION
Some servers / virtual hosting solutions don't deal with ":80" at the end of the host name properly.

This is similar to what e.g. curl does since October 2000:
https://github.com/curl/curl/blob/master/lib/http.c#L2150

See also: https://github.com/curl/curl/commit/c44b10de41ffca204acf11f36093c24521119239