### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ Single-file public domain libraries for C/C++ (dual licensed under MIT).
 * [strpool.h](docs/strpool.md) - Highly efficient string pool for C/C++.
 * [thread.h](docs/thread.md) - Cross platform threading functions for C/C++.
 
+# Installing mgnlibs(vcpkg)
+
+You can download and install mgnlibs using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install mgnlibs
+
+The mgnlibs port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Single-file public domain libraries for C/C++ (dual licensed under MIT).
 * [thread.h](docs/thread.md) - Cross platform threading functions for C/C++.
 
 # Installing mgnlibs(vcpkg)
-
 You can download and install mgnlibs using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh
-./vcpkg integrate install
-vcpkg install mgnlibs
+* git clone https://github.com/Microsoft/vcpkg.git
+* cd vcpkg
+* ./bootstrap-vcpkg.sh
+* ./vcpkg integrate install
+* vcpkg install mgnlibs
 
 The mgnlibs port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`mgnlibs` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for mgnlibs and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build mgnlibs, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/mgnlibs/portfile.cmake). We try to keep the library maintained as close as possible to the original library.