### PR TITLE
thread.h: memset() requires <string.h>

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -621,6 +621,7 @@ struct thread_queue_t
 
     #include <pthread.h>
     #include <errno.h>
+    #include <string.h>
     #include <sys/time.h>
 
 #else 


### PR DESCRIPTION
https://github.com/mattiasgustavsson/libs/blob/6559fb2c434d7055a746eaa7bbaec33efdcbdcf6/thread.h#L768

```
/Users/.../thread.h:768:9: error: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Werror,-Wimplicit-function-declaration]
        memset( &sp, 0, sizeof( sp ) );
        ^
/Users/.../thread.h:768:9: note: include the header <string.h> or explicitly provide a declaration for 'memset'
1 error generated.
ninja: build stopped: subcommand failed.
```

Clang version f.y.i:
```
Apple clang version 13.0.0 (clang-1300.0.29.30)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
```