### PR TITLE
Fixed thread_atomic_int_store() on non-Windows systems

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -1041,8 +1041,8 @@ void thread_atomic_int_store( thread_atomic_int_t* atomic, int desired )
 
         __sync_fetch_and_and( &atomic->i, 0 );
         __sync_fetch_and_or( &atomic->i, desired );
-
-#else 
+    
+    #else 
         #error Unknown platform.
     #endif
     }

--- a/thread.h
+++ b/thread.h
@@ -1039,10 +1039,10 @@ void thread_atomic_int_store( thread_atomic_int_t* atomic, int desired )
 
     #elif defined( __linux__ ) || defined( __APPLE__ ) || defined( __ANDROID__ )
 
-        __sync_lock_test_and_set( &atomic->i, desired );
-        __sync_lock_release( &atomic->i );
-    
-    #else 
+        __sync_fetch_and_and( &atomic->i, 0 );
+        __sync_fetch_and_or( &atomic->i, desired );
+
+#else 
         #error Unknown platform.
     #endif
     }


### PR DESCRIPTION
The `thread_atomic_int_store()` function was previously setting the value of the atomic to 0 on non-Windows systems. I modified it to use the `__sync_fetch_and_or()` and `__sync_fetch_and_and()` built-ins which eliminates the issue. The `__sync_lock_release()` built-in call used previously sets the value of the atomic to 0 as described [here](https://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html).