### PR TITLE
Include <stdint.h> on non-Windows platforms

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -623,6 +623,7 @@ struct thread_queue_t
     #include <errno.h>
     #include <string.h>
     #include <sys/time.h>
+    #include <stdint.h>
 
 #else 
     #error Unknown platform.


### PR DESCRIPTION
If `<stdint.h>` is not already included by the user's program, there will be no definition for the `uintptr_t` type so the library will not compile.